### PR TITLE
Add @package to the docs

### DIFF
--- a/can-reflect-promise.md
+++ b/can-reflect-promise.md
@@ -1,5 +1,6 @@
 @function {Promise} can-reflect-promise
 @parent can-ecosystem
+@package ./package.json
 @description Expose an observable, Map-like API on Promise types.
 
 @signature `canReflectPromise(promise)`


### PR DESCRIPTION
This fixes an issue with the GitHub star and npm download buttons not appearing in the rendered canjs.com docs.