### PR TITLE
Break jquery Deferred tests out into their own module

### DIFF
--- a/test/can-reflect-promise_test.js
+++ b/test/can-reflect-promise_test.js
@@ -2,7 +2,6 @@ var QUnit = require("steal-qunit");
 var GLOBAL = require("can-util/js/global/global");
 var canSymbol = require("can-symbol");
 var canReflectPromise = require("can-reflect-promise");
-var $ = require("can-jquery");
 
 var nativePromise = GLOBAL().Promise;
 var Promise;
@@ -96,84 +95,3 @@ QUnit.test("onKeyValue for promise-specific values", 3, function() {
 	});
 });
 
-QUnit.module("can-reflect-promise with jQuery.Deferred", {
-	// $.Deferred isn't a prototype-enabled type, just an object
-	//  that gets generated on demand, so no fancy setup is needed here.
-});
-
-QUnit.test("decorates promise", function() {
-	var d = $.Deferred();
-	QUnit.ok(!d[canSymbol.for("can.getKeyValue")], "no decoration");
-
-	canReflectPromise(d);
-	QUnit.ok(d[canSymbol.for("can.getKeyValue")], "has decoration");
-	QUnit.ok(d.hasOwnProperty(canSymbol.for("can.getKeyValue")), "decoration strictly on object");
-	QUnit.ok(!Object.prototype[canSymbol.for("can.getKeyValue")], "decoration not on proto");
-
-});
-
-QUnit.test("has all necessary symbols", function() {
-	var d = new $.Deferred();
-	canReflectPromise(d);
-	QUnit.ok(d[canSymbol.for("can.getKeyValue")], "can.getKeyValue");
-	QUnit.ok(d[canSymbol.for("can.getValue")], "can.getValue");
-	QUnit.ok(d[canSymbol.for("can.onValue")], "can.onValue");
-	QUnit.ok(d[canSymbol.for("can.onKeyValue")], "can.onKeyValue");
-	QUnit.equal(d[canSymbol.for("can.isValueLike")], false, "can.isValueLike");
-
-});
-
-QUnit.test("getKeyValue for promise-specific values", 8, function() {
-	var d = new $.Deferred();
-	canReflectPromise(d);
-	QUnit.equal(d[canSymbol.for("can.getKeyValue")]("isPending"), true, "isPending true in sync");
-	QUnit.equal(d[canSymbol.for("can.getKeyValue")]("isResolved"), false, "isResolved false in sync");
-	QUnit.equal(d[canSymbol.for("can.getKeyValue")]("value"), undefined, "no value in sync");
-	QUnit.equal(d[canSymbol.for("can.getKeyValue")]("state"), "pending", "state pending in sync");
-	stop();
-
-	d.resolve("a"); // in some jQuery versions, resolving is sync
-	setTimeout(function() {
-		QUnit.equal(d[canSymbol.for("can.getKeyValue")]("value"), "a", "value in async");
-		QUnit.equal(d[canSymbol.for("can.getKeyValue")]("isPending"), false, "isPending false in async");
-		QUnit.equal(d[canSymbol.for("can.getKeyValue")]("isResolved"), true, "isResolved true in async");
-		QUnit.equal(d[canSymbol.for("can.getKeyValue")]("state"), "resolved", "state resolved in async");
-		start();
-	}, 10);
-});
-
-QUnit.test("onKeyValue for promise-specific values", 4, function() {
-	stop(4);
-	var d = new $.Deferred();
-	canReflectPromise(d);
-	d[canSymbol.for("can.onKeyValue")]("value", function(newVal) {
-		QUnit.equal(newVal, "a", "value updates on event");
-		start();
-	});
-	d[canSymbol.for("can.onValue")](function(newVal) {
-		QUnit.equal(newVal, "a", "value updates on event with onValue");
-		start();
-	});
-	d[canSymbol.for("can.onKeyValue")]("isResolved", function(newVal) {
-		QUnit.equal(newVal, true, "isResolved updates on event");
-		start();
-	});
-	d[canSymbol.for("can.onKeyValue")]("state", function(newVal) {
-		QUnit.equal(newVal, "resolved", "state updates on event");
-		start();
-	});
-	d.resolve("a");
-});
-
-QUnit.test("getKeyValue on $.Deferred().promise()", 2, function() {
-	var d = new $.Deferred();
-	canReflectPromise(d);
-	QUnit.equal(d.promise()[canSymbol.for("can.getKeyValue")]("value"), undefined, "no value in sync");
-	stop();
-
-	d.resolve("a"); // in some jQuery versions, resolving is sync
-	setTimeout(function() {
-		QUnit.equal(d.promise()[canSymbol.for("can.getKeyValue")]("value"), "a", "value in async");
-		start();
-	}, 10);
-});

--- a/test/jquery-deferred_test.js
+++ b/test/jquery-deferred_test.js
@@ -1,0 +1,86 @@
+var QUnit = require("steal-qunit");
+var canSymbol = require("can-symbol");
+var canReflectPromise = require("can-reflect-promise");
+var $ = require("can-jquery");
+
+QUnit.module("can-reflect-promise with jQuery.Deferred", {
+	// $.Deferred isn't a prototype-enabled type, just an object
+	//  that gets generated on demand, so no fancy setup is needed here.
+});
+
+QUnit.test("decorates promise", function() {
+	var d = $.Deferred();
+	QUnit.ok(!d[canSymbol.for("can.getKeyValue")], "no decoration");
+
+	canReflectPromise(d);
+	QUnit.ok(d[canSymbol.for("can.getKeyValue")], "has decoration");
+	QUnit.ok(d.hasOwnProperty(canSymbol.for("can.getKeyValue")), "decoration strictly on object");
+	QUnit.ok(!Object.prototype[canSymbol.for("can.getKeyValue")], "decoration not on proto");
+
+});
+
+QUnit.test("has all necessary symbols", function() {
+	var d = new $.Deferred();
+	canReflectPromise(d);
+	QUnit.ok(d[canSymbol.for("can.getKeyValue")], "can.getKeyValue");
+	QUnit.ok(d[canSymbol.for("can.getValue")], "can.getValue");
+	QUnit.ok(d[canSymbol.for("can.onValue")], "can.onValue");
+	QUnit.ok(d[canSymbol.for("can.onKeyValue")], "can.onKeyValue");
+	QUnit.equal(d[canSymbol.for("can.isValueLike")], false, "can.isValueLike");
+
+});
+
+QUnit.test("getKeyValue for promise-specific values", 8, function() {
+	var d = new $.Deferred();
+	canReflectPromise(d);
+	QUnit.equal(d[canSymbol.for("can.getKeyValue")]("isPending"), true, "isPending true in sync");
+	QUnit.equal(d[canSymbol.for("can.getKeyValue")]("isResolved"), false, "isResolved false in sync");
+	QUnit.equal(d[canSymbol.for("can.getKeyValue")]("value"), undefined, "no value in sync");
+	QUnit.equal(d[canSymbol.for("can.getKeyValue")]("state"), "pending", "state pending in sync");
+	stop();
+
+	d.resolve("a"); // in some jQuery versions, resolving is sync
+	setTimeout(function() {
+		QUnit.equal(d[canSymbol.for("can.getKeyValue")]("value"), "a", "value in async");
+		QUnit.equal(d[canSymbol.for("can.getKeyValue")]("isPending"), false, "isPending false in async");
+		QUnit.equal(d[canSymbol.for("can.getKeyValue")]("isResolved"), true, "isResolved true in async");
+		QUnit.equal(d[canSymbol.for("can.getKeyValue")]("state"), "resolved", "state resolved in async");
+		start();
+	}, 10);
+});
+
+QUnit.test("onKeyValue for promise-specific values", 4, function() {
+	stop(4);
+	var d = new $.Deferred();
+	canReflectPromise(d);
+	d[canSymbol.for("can.onKeyValue")]("value", function(newVal) {
+		QUnit.equal(newVal, "a", "value updates on event");
+		start();
+	});
+	d[canSymbol.for("can.onValue")](function(newVal) {
+		QUnit.equal(newVal, "a", "value updates on event with onValue");
+		start();
+	});
+	d[canSymbol.for("can.onKeyValue")]("isResolved", function(newVal) {
+		QUnit.equal(newVal, true, "isResolved updates on event");
+		start();
+	});
+	d[canSymbol.for("can.onKeyValue")]("state", function(newVal) {
+		QUnit.equal(newVal, "resolved", "state updates on event");
+		start();
+	});
+	d.resolve("a");
+});
+
+QUnit.test("getKeyValue on $.Deferred().promise()", 2, function() {
+	var d = new $.Deferred();
+	canReflectPromise(d);
+	QUnit.equal(d.promise()[canSymbol.for("can.getKeyValue")]("value"), undefined, "no value in sync");
+	stop();
+
+	d.resolve("a"); // in some jQuery versions, resolving is sync
+	setTimeout(function() {
+		QUnit.equal(d.promise()[canSymbol.for("can.getKeyValue")]("value"), "a", "value in async");
+		start();
+	}, 10);
+});

--- a/test/test.html
+++ b/test/test.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <title>can-reflect-promise</title>
-<script src="../node_modules/steal/steal.js" main="can-reflect-promise/test/can-reflect-promise_test"></script>
+<script src="../node_modules/steal/steal.js" main="can-reflect-promise/test/test"></script>
 <div id="qunit-fixture"></div>

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,2 @@
+require("./can-reflect-promise_test");
+require("./jquery-deferred_test");

--- a/test/test_native.html
+++ b/test/test_native.html
@@ -1,4 +1,4 @@
 <!DOCTYPE html>
 <title>can-reflect-promise</title>
-<script src="../node_modules/steal/steal-sans-promises.js" main="can-reflect-promise/test/can-reflect-promise_test"></script>
+<script src="../node_modules/steal/steal-sans-promises.js" main="can-reflect-promise/test/test"></script>
 <div id="qunit-fixture"></div>


### PR DESCRIPTION
This enables the non-jquery tests to go into the canjs/canjs integration suite, while the ones that depend on can-jquery (which breaks the normal integration tests) are now isolated but still run as part of the test suite within can-reflect-promise.