### PR TITLE
Fix tests for canjs integration (unintentional statefulness)

### DIFF
--- a/test/can-reflect-promise_test.js
+++ b/test/can-reflect-promise_test.js
@@ -31,7 +31,18 @@ QUnit.module("can-reflect-promise", {
 				tempPromise[key] = new Function("value", "return new this(function(resolve, reject) { " + key + "(value); });");
 			}
 		});
-		tempPromise.prototype = Object.create(nativePromise.prototype);
+
+		var protoDefs = {};
+		protoDefs[canSymbol.for("can.observeData")] = {
+			value: null,
+			writable: true
+		};
+		protoDefs[canSymbol.for("can.getKeyValue")] = {
+			value: null,
+			writable: true
+		};
+
+		tempPromise.prototype = Object.create(nativePromise.prototype, protoDefs);
 
 		Promise = tempPromise;
 	},


### PR DESCRIPTION
Cases where Promise was already reflected caused breakage in canjs integration tests.  In this PR, the symbols for reflectifying and for checking whether to reflectify are defined as null in the test promise prototype.