### PR TITLE
Fix IE tests

### DIFF
--- a/test/can-reflect-promise_test.js
+++ b/test/can-reflect-promise_test.js
@@ -35,11 +35,13 @@ QUnit.module("can-reflect-promise", {
 		var protoDefs = {};
 		protoDefs[canSymbol.for("can.observeData")] = {
 			value: null,
-			writable: true
+			writable: true,
+			configurable: true
 		};
 		protoDefs[canSymbol.for("can.getKeyValue")] = {
 			value: null,
-			writable: true
+			writable: true,
+			configurable: true
 		};
 
 		tempPromise.prototype = Object.create(nativePromise.prototype, protoDefs);


### PR DESCRIPTION
non-configurable override symobls  on the test promise class were causing IE to fail when trying to set their values (because polyfilled symbols use redefinition).