### PR TITLE
fix dev code for webpack compatibility

### DIFF
--- a/can-reflect-promise.js
+++ b/can-reflect-promise.js
@@ -55,7 +55,9 @@ function initPromise(promise) {
 		queues.batch.stop();
 
 		//!steal-remove-start
-		dev.error("Failed promise:", reason);
+		if (process.env.NODE_ENV !== 'production') {
+			dev.error("Failed promise:", reason);
+		}
 		//!steal-remove-end
 	});
 }


### PR DESCRIPTION
This fixes the first part of this issue canjs/canjs#4170 to remove debug code from the production builds.